### PR TITLE
Change URL format to msdn.microsoft.com

### DIFF
--- a/MsdnResolver/MsdnUrlFinder.cs
+++ b/MsdnResolver/MsdnUrlFinder.cs
@@ -8,7 +8,7 @@ namespace MsdnResolver
 {
     internal sealed class MsdnUrlFinder
     {
-        private const string UrlFormat = "http://msdn2.microsoft.com/{0}/library/{1}";
+        private const string UrlFormat = "http://msdn.microsoft.com/{0}/library/{1}";
         private const string Locale = "en-us";
 
         private readonly MsdnWebService _msdnWebService = new MsdnWebService("Microsoft.Fx.Msdn");

--- a/MsdnResolver/Program.cs
+++ b/MsdnResolver/Program.cs
@@ -20,7 +20,7 @@ namespace MsdnResolver
             var url = await finder.GetUrlAsync(documentationId);
 
             // Prints
-            // http://msdn2.microsoft.com/en-us/library/6sh2ey19
+            // http://msdn.microsoft.com/en-us/library/6sh2ey19
             Console.WriteLine(url);
         }
     }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MSDN Resolver
 
 This simple console app shows how you can get an MSDN URL, such as
-<http://msdn2.microsoft.com/en-us/library/6sh2ey19>, from an API,
+<http://msdn.microsoft.com/en-us/library/6sh2ey19>, from an API,
 such as ``T:System.Collections.Generic.List`1``:
 
 ```C#
@@ -13,6 +13,6 @@ var finder = new MsdnUrlFinder();
 var url = await finder.GetUrlAsync(documentationId);
 
 // Prints
-// http://msdn2.microsoft.com/en-us/library/6sh2ey19
+// http://msdn.microsoft.com/en-us/library/6sh2ey19
 Console.WriteLine(url);
 ```


### PR DESCRIPTION
msdn2.microsoft.com is redirecting to msdn.microsoft.com so it's "faster" to go directly to last address.
